### PR TITLE
feat: include openssh in docker image

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -22,6 +22,7 @@ let
     findutils
     iana-etc
     git
+    openssh
   ];
 
   users = {


### PR DESCRIPTION
When leveraging remote builders or cache in CI workloads, sometimes you need to configure nix to connect via SSH to a remote server.

It is the case for example when using nixbuild.net.

By including `openssh` package, CI should be able to reach remote builders when configured i.e. with environment variables.

@moduon MT-83